### PR TITLE
Avoid recompilation.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -11,10 +11,16 @@
 
 final: prev: {
   kdePackages = prev.kdePackages.overrideScope (kfinal: kprev: {
-    dolphin-wrapped = prev.writeShellScriptBin "dolphin" ''
-              export XDG_CONFIG_DIRS="${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS"
-              ${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu
-              exec ${kprev.dolphin}/bin/dolphin
-    '';
+    dolphin = prev.symlinkJoin {
+      name = "dolphin-wrapped";
+      paths = [ kprev.dolphin ];
+      nativeBuildInputs = [ prev.makeWrapper ];
+      postBuild = ''
+        rm $out/bin/dolphin
+        makeWrapper ${kprev.dolphin}/bin/dolphin $out/bin/dolphin \
+          --set XDG_CONFIG_DIRS "${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS" \
+          --run "${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu"
+      '';
+    };
   });
 }

--- a/default.nix
+++ b/default.nix
@@ -11,13 +11,10 @@
 
 final: prev: {
   kdePackages = prev.kdePackages.overrideScope (kfinal: kprev: {
-    dolphin = kprev.dolphin.overrideAttrs (oldAttrs: {
-      nativeBuildInputs = (oldAttrs.nativeBuildInputs or []) ++ [ prev.makeWrapper ];
-      postInstall = (oldAttrs.postInstall or "") + ''
-        wrapProgram $out/bin/dolphin \
-            --set XDG_CONFIG_DIRS "${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS" \
-            --run "${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu"
-      '';
-    });
+    dolphin-wrapped = prev.writeShellScriptBin "dolphin" ''
+              export XDG_CONFIG_DIRS="${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS"
+              ${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu
+              exec ${kprev.dolphin}/bin/dolphin
+    '';
   });
 }


### PR DESCRIPTION
Use `writeShellScriptBin` instead of `makeWrapper` to create a derivation which only has the desired script calling `dolphin`. This avoids compiling `dolphin` locally.

Since the derivation now no longer contains other files from `dolphin`, I renamed the package to `dolphin-wrapped`. If there is any use-case where this is undesirable (because some package calls `${pkgs.kdePackages.dolphin}/bin/dolphin`), it should be possible to make symlinks to `pkgs.kdePackages.dolphin` while still avoiding local compilation.