### PR TITLE
Fix a regression for dolphin-plugins

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -13,7 +13,7 @@ final: prev: {
   kdePackages = prev.kdePackages.overrideScope (kfinal: kprev: {
     dolphin = prev.symlinkJoin {
       name = "dolphin-wrapped";
-      paths = [ kprev.dolphin ];
+      paths = [ kprev.dolphin kprev.dolphin.dev ];
       nativeBuildInputs = [ prev.makeWrapper ];
       postBuild = ''
         rm $out/bin/dolphin
@@ -21,6 +21,7 @@ final: prev: {
           --set XDG_CONFIG_DIRS "${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS" \
           --run "${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu"
       '';
+      passthru = (kprev.dolphin.passthru or {}) // { dev = kprev.dolphin.dev; };
     };
   });
 }


### PR DESCRIPTION
After recent merge of #3, `kdePackages.dolphin-plugins` package started failing to build. This PR fixes this error and makes derivation evaluate successfully (still using cached version of dolphin-plugins from cache.nixos.org without forcing package rebuild).

The log of failed build:
```
error: Cannot build '/nix/store/yfsn9avw8n6v08znvn2syn83lk6rp3jr-dolphin-plugins-25.12.3.drv'.
       Reason: builder failed with exit code 1.
       Output paths:
         /nix/store/0q3yadqpxp9z39wqshia259bdxz413qb-dolphin-plugins-25.12.3-devtools
         /nix/store/cd8ybk0064js4hdr2qvlz5i72whnglpa-dolphin-plugins-25.12.3-debug
         /nix/store/wrjzdl1xfmh1l6iyh6ybbdy6zksc5mq7-dolphin-plugins-25.12.3-dev
         /nix/store/xpysa5znxrxcfajfckmaxrngxq730aq6-dolphin-plugins-25.12.3
       Last 25 log lines:
       > -- Looking for shmat - found
       > -- Found KF6KIO: /nix/store/aj0yviyvkrsbbbmkfcm86sawghady5az-kio-6.25.0-dev/lib/cmake/KF6KIO/KF6KIOConfig.cmake (found version "6.25.0")
       > -- Found KF6TextWidgets: /nix/store/gb3zaf3svvw1yrzmn01s85pfj4b584n9-ktextwidgets-6.25.0-dev/lib/cmake/KF6TextWidgets/KF6TextWidgetsConfig.cmake (found version "6.25.0")
       > -- Found KF6Config: /nix/store/dqvi8xlmwzrbnxcsgj2clraamk1g74sv-kconfig-6.25.0-dev/lib/cmake/KF6Config/KF6ConfigConfig.cmake (found version "6.25.0")
       > -- Found KF6CoreAddons: /nix/store/35qvh4qmihvdzr69inr1rrr1pndwrmvh-kcoreaddons-6.25.0-dev/lib/cmake/KF6CoreAddons/KF6CoreAddonsConfig.cmake (found version "6.25.0")
       > -- Found KF6Solid: /nix/store/vfggwhb2qigykxdsqy1zq9hy17040hs0-solid-6.25.0-dev/lib/cmake/KF6Solid/KF6SolidConfig.cmake (found version "6.25.0")
       > -- Found KF6: success (found suitable version "6.25.0", minimum required is "6.0.0") found components: XmlGui I18n KIO TextWidgets Config CoreAddons Solid
       > CMake Error at CMakeLists.txt:48 (find_package):
       >   By not providing "FindDolphinVcs.cmake" in CMAKE_MODULE_PATH this project
       >   has asked CMake to find a package configuration file provided by
       >   "DolphinVcs", but CMake did not find one.
       >
       >   Could not find a package configuration file provided by "DolphinVcs" with
       >   any of the following names:
       >
       >     DolphinVcsConfig.cmake
       >     dolphinvcs-config.cmake
       >
       >   Add the installation prefix of "DolphinVcs" to CMAKE_PREFIX_PATH or set
       >   "DolphinVcs_DIR" to a directory containing one of the above files.  If
       >   "DolphinVcs" provides a separate development package or SDK, be sure it has
       >   been installed.
       >
       > 
       > -- Configuring incomplete, errors occurred!
```
