### PR TITLE
Directly download applications.menu from KDE GitLab

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,17 +10,40 @@
 # The modified package retains its original GPL license.
 
 final: prev: {
-  kdePackages = prev.kdePackages.overrideScope (kfinal: kprev: {
-    dolphin = prev.symlinkJoin {
-      name = "dolphin-wrapped";
-      paths = [ kprev.dolphin ];
-      nativeBuildInputs = [ prev.makeWrapper ];
-      postBuild = ''
-        rm $out/bin/dolphin
-        makeWrapper ${kprev.dolphin}/bin/dolphin $out/bin/dolphin \
-          --set XDG_CONFIG_DIRS "${prev.libsForQt5.kservice}/etc/xdg:$XDG_CONFIG_DIRS" \
-          --run "${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${prev.libsForQt5.kservice}/etc/xdg/menus/applications.menu"
-      '';
-    };
-  });
+  kdePackages = prev.kdePackages.overrideScope (
+    kfinal: kprev:
+    let
+      kservice5Menu = prev.stdenv.mkDerivation {
+        name = "kservice5-applications-menu";
+        version = "5.116.0";
+
+        src = prev.fetchFromGitLab {
+          domain = "invent.kde.org";
+          owner = "frameworks";
+          repo = "kservice";
+          tag = "v5.116.0";
+          sparseCheckout = [ "src/applications.menu" ];
+          hash = "sha256-28ueuJiI34o1wayiq85KPNkUCwjdhPMYtU2nJTQ84V4=";
+        };
+
+        installPhase = ''
+          mkdir -p $out/etc/xdg/menus
+          cp ./src/applications.menu $out/etc/xdg/menus/applications.menu
+        '';
+      };
+    in
+    {
+      dolphin = prev.symlinkJoin {
+        name = "dolphin-wrapped";
+        paths = [ kprev.dolphin ];
+        nativeBuildInputs = [ prev.makeWrapper ];
+        postBuild = ''
+          rm $out/bin/dolphin
+          makeWrapper ${kprev.dolphin}/bin/dolphin $out/bin/dolphin \
+            --set XDG_CONFIG_DIRS "${kservice5Menu}/etc/xdg:$XDG_CONFIG_DIRS" \
+            --run "${kprev.kservice}/bin/kbuildsycoca6 --noincremental ${kservice5Menu}/etc/xdg/menus/applications.menu"
+        '';
+      };
+    }
+  );
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743890059,
-        "narHash": "sha256-QQLhHHGNtAW8qRpseb40zqZlhZUeRRUg2SGmXjfE+so=",
+        "lastModified": 1778856625,
+        "narHash": "sha256-ExyHGgqlnO56XEn3NRn3PgdqCuwne+GZ5yLLUC7RE9I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "58a813438464b5295170efe38d8bd5f40fcc1d23",
+        "rev": "e9e9a640d9a61d77d52da7ac3e755a975a2ed0cf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
The latest nixpkgs broke this overlay because `libsForQt5.kservice` was removed. The QT 6 version doesn't have the menu file. This PR adds in a derivation that downloads the file from the KDE GitLab and places it in the expected location.

I also updated the nixpkgs version in order to make this actually matter without overriding it in your own flake.